### PR TITLE
FIX: 調教中ショップで一部の酒が購入できない問題

### DIFF
--- a/ERB/TRAIN/USERCOM.ERB
+++ b/ERB/TRAIN/USERCOM.ERB
@@ -1277,7 +1277,12 @@ CALL SINGLE_DRAWLINE
 FOR LOCAL, 0, VARSIZE("SELLING")
 	{
 		SIF !GROUPMATCH(LOCAL,
-			GETNUM(ITEM, "ローション"), 
+			GETNUM(ITEM, "粗製ビール"),
+			GETNUM(ITEM, "粗製ワイン"),
+			GETNUM(ITEM, "アストロ・フィズ"),
+			GETNUM(ITEM, "ピルスナー"),
+			GETNUM(ITEM, "エインズの露"),
+			GETNUM(ITEM, "ローション"),
 			GETNUM(ITEM, "利尿剤"),
 			GETNUM(ITEM, "コンドーム"),
 			GETNUM(ITEM, "ライスワイン"),


### PR DESCRIPTION
最初期に実装された酒群と後から追加された酒群とで対応が分かれていたので統一
Item.csvで日常消耗品と消耗品とが別々においてあるのが遠因かと思います
tohoK由来のバグです